### PR TITLE
Ta funkce prostě někde být musí....

### DIFF
--- a/STM8S-toolchain/src/stm8s_it.c
+++ b/STM8S-toolchain/src/stm8s_it.c
@@ -455,12 +455,12 @@ INTERRUPT_HANDLER(TIM6_UPD_OVF_TRG_IRQHandler, 23)
   * @param  None
   * @retval None
   */
-/*INTERRUPT_HANDLER(TIM4_UPD_OVF_IRQHandler, 23)*/
-/*{*/
+INTERRUPT_HANDLER(TIM4_UPD_OVF_IRQHandler, 23)
+{
 /*    TimingDelay_Decrement();*/
 /*    [> Cleat Interrupt Pending bit <]*/
 /*    TIM4_ClearITPendingBit(TIM4_IT_UPDATE);*/
-/*}*/
+}
 #endif /*STM8S903*/
 
 /**


### PR DESCRIPTION
... a když není v `milis.c` musí být někde jinde... nejlépe v `stm8s_it.c`.